### PR TITLE
仮データだったのをentityから受け取るよう修正

### DIFF
--- a/src/migration/1727278024700-add-request-created.ts
+++ b/src/migration/1727278024700-add-request-created.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddRequestCreated1727278024700 implements MigrationInterface {
+    name = 'AddRequestCreated1727278024700'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "request" DROP COLUMN "createdAt"`);
+        await queryRunner.query(`ALTER TABLE "request" ADD "created_at" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "request" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`ALTER TABLE "request" ADD "updated_at" TIMESTAMP NOT NULL DEFAULT now()`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "request" DROP COLUMN "updated_at"`);
+        await queryRunner.query(`ALTER TABLE "request" ADD "updated_at" date NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "request" DROP COLUMN "created_at"`);
+        await queryRunner.query(`ALTER TABLE "request" ADD "createdAt" date NOT NULL`);
+    }
+
+}

--- a/src/module/request/request.controller.ts
+++ b/src/module/request/request.controller.ts
@@ -12,10 +12,10 @@ export class RequestController {
   }
 
   @Get('/')
-  async getAll(@Req() req: Request, @Res() res: Response, next: NextFunction) {
+  async getAll(@Req() _req: Request, @Res() res: Response, next: NextFunction) {
     try {
-      const orders = await this.requestService.getAll()
-      return res.json(orders)
+      const requests = await this.requestService.getAll()
+      return res.json(requests)
     } catch (error) {
       next(error)
     }
@@ -24,12 +24,13 @@ export class RequestController {
   @Get('/:id')
   async getOneById(
     @Param('id') id: number,
+    @Req() _req: Request,
     @Res() res: Response,
     next: NextFunction,
   ) {
     try {
-      const order = await this.requestService.getOneById(id)
-      return res.json(order)
+      const request = await this.requestService.getOneById(id)
+      return res.json(request)
     } catch (error) {
       next(error)
     }

--- a/src/module/request/request.entity.ts
+++ b/src/module/request/request.entity.ts
@@ -1,64 +1,74 @@
 import { IsEmail, IsNotEmpty, IsString, ValidateIf } from 'class-validator'
-import { Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm'
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+} from 'typeorm'
 
 import { User } from '../user/user.entity'
 import { Item } from '../item/item.entity'
 
 export enum status {
-    pending = "pending",
-    progress = "progress",
-    completed = "completed"
+  pending = 'pending',
+  progress = 'progress',
+  completed = 'completed',
 }
 
 @Entity()
 export class Request {
-    @PrimaryGeneratedColumn()
-    id!: number
-  
-    @Column('varchar')
-    @IsString()
-    @IsNotEmpty()
-    title!: string
+  @PrimaryGeneratedColumn()
+  id!: number
 
-    @Column("varchar")
-    @IsString()
-    location_prefecture!: string
+  @Column('varchar')
+  @IsString()
+  @IsNotEmpty()
+  title!: string
 
-    @Column("varchar")
-    @IsString()
-    location_details!: string
-    
-    @Column("varchar", {nullable:true})
-    @IsString()
-    delivery_location: string | null = null
+  @Column('varchar')
+  @IsString()
+  location_prefecture!: string
 
-    @Column("date", {nullable:true})
-    delivery_date: Date | null = null
+  @Column('varchar')
+  @IsString()
+  location_details!: string
 
-    @Column("text")
-    @IsString()
-    description!: String
+  @Column('varchar', { nullable: true })
+  @IsString()
+  delivery_location: string | null = null
 
-    @Column({
-        type: "varchar",
-        enum: status,
-        default: status.pending
-    })
-    status!: status
+  @Column('date', { nullable: true })
+  delivery_date: Date | null = null
 
-    @ManyToOne(() => User, (user) => user.requests)
-    user!: User
+  @Column('text')
+  @IsString()
+  description!: String
 
-    @Column("date")
-    createdAt!: Date
+  @Column({
+    type: 'varchar',
+    enum: status,
+    default: status.pending,
+  })
+  status!: status
 
-    @Column("date")
-    updated_at!: Date
+  @ManyToOne(() => User, (user) => user.requests)
+  user!: User
 
-    @Column("date", {nullable:true})
-    completed_at: Date | null = null
+  @CreateDateColumn({
+    update: false,
+  })
+  created_at!: Date
 
-    @OneToMany(() => Item, (item) => item.request)
-    items!: Item[]
-  
+  @CreateDateColumn({
+    update: true,
+  })
+  updated_at!: Date
+
+  @Column('date', { nullable: true })
+  completed_at: Date | null = null
+
+  @OneToMany(() => Item, (item) => item.request)
+  items!: Item[]
 }

--- a/src/module/request/request.service.ts
+++ b/src/module/request/request.service.ts
@@ -4,12 +4,12 @@ import { Request } from './request.entity'
 const requestRepository = AppDataSource.getRepository(Request)
 
 export class RequestService {
-  async getAll() {
-    return requestRepository.find()
+  async getAll(): Promise<Request[]> {
+    return await requestRepository.find()
   }
 
-  async getOneById(id: number) {
-    const request = requestRepository.findOne({ where: { id } })
+  async getOneById(id: number): Promise<Request> {
+    const request = await requestRepository.findOne({ where: { id } })
     if (!request) {
       throw new Error(`Order with id ${id} not found`)
     }

--- a/src/module/request/request.service.ts
+++ b/src/module/request/request.service.ts
@@ -1,38 +1,18 @@
-export class RequestService {
-  private orders = [
-    {
-      id: 101,
-      title: '～に行ってきて',
-      place: '東京',
-      item: '～のライブの限定品',
-      limit: '2024/10/10',
-      description:
-        '東京の10月5日に開かれるライブで販売される限定品を買ってきてください',
-      createdAt: '2024/09/17',
-      user_id: 0,
-    },
-    {
-      id: 102,
-      title: '～に行ってきて',
-      place: '東京',
-      item: '～のライブの限定品',
-      limit: '2024/10/10',
-      description:
-        '東京の10月5日に開かれるライブで販売される限定品を買ってきてください',
-      createdAt: '2024/09/17',
-      user_id: 0,
-    },
-  ]
+import { AppDataSource } from '../../app-data-source'
+import { Request } from './request.entity'
 
+const requestRepository = AppDataSource.getRepository(Request)
+
+export class RequestService {
   async getAll() {
-    return this.orders
+    return requestRepository.find()
   }
 
   async getOneById(id: number) {
-    const order = this.orders.find((order) => order.id === id)
-    if (!order) {
+    const request = requestRepository.findOne({ where: { id } })
+    if (!request) {
       throw new Error(`Order with id ${id} not found`)
     }
-    return order
+    return request
   }
 }


### PR DESCRIPTION
今まで仮データを使用していたRequestのGet処理を実際にentityから受け取るよう修正しました。
APIDogで実際に値が返ってくることを確認済みです。
あとentityのカラムを@CreateDateColumnに変更してます。

RequestにもTypeファイル作りたかったんやけど、POST、PUTメソッドを作るときにまとめて作成した方が良いかなの考えで一旦作ってないです、必要だったらすぐ作ります。