### PR TITLE
UserUpdateAPI作成

### DIFF
--- a/backend/src/module/request/request.entity.ts
+++ b/backend/src/module/request/request.entity.ts
@@ -6,6 +6,7 @@ import {
   OneToMany,
   PrimaryGeneratedColumn,
   CreateDateColumn,
+  UpdateDateColumn,
 } from 'typeorm'
 
 import { User } from '../user/user.entity'
@@ -62,7 +63,7 @@ export class Request {
   @OneToMany(() => Room, (room) => room.request)
   rooms!: Room[]
 
-  @CreateDateColumn({
+  @UpdateDateColumn({
     update: true,
   })
   updated_at!: Date

--- a/backend/src/module/user/user.controller.ts
+++ b/backend/src/module/user/user.controller.ts
@@ -12,7 +12,7 @@ import {
 import { UserService } from './user.service'
 import { generateToken } from '../../utils/token'
 import { userSerializer } from './user.serializer'
-import { GetUser, SignUp, Update } from './user.type'
+import { GetUser, SignUp, UpdateUserParam } from './user.type'
 import { setCurrentUser } from 'src/middleware/setCurrentUser'
 
 @Controller()
@@ -41,15 +41,15 @@ export class UserController {
     return res.json({ user: userSerializer(user) })
   }
 
-  @Patch(Update.endpoint)
+  @Patch(UpdateUserParam.endpoint)
   @Authorized()
-  async update(
-    @Req() req: Request<{}, {}, Update.req, {}>,
-    @Res() res: Response<Update.res>,
+  async updateUserParam(
+    @Req() req: Request<{}, {}, UpdateUserParam.req, {}>,
+    @Res() res: Response<UpdateUserParam.res>,
   ) {
     const userId = req.currentUserId!
     const { inputName, inputEmail } = req.body
-    const user = await this.userService.update({
+    const user = await this.userService.updateUserParam({
       userId,
       inputName,
       inputEmail,

--- a/backend/src/module/user/user.controller.ts
+++ b/backend/src/module/user/user.controller.ts
@@ -7,11 +7,12 @@ import {
   Req,
   Res,
   Authorized,
+  Patch,
 } from 'routing-controllers'
 import { UserService } from './user.service'
 import { generateToken } from '../../utils/token'
 import { userSerializer } from './user.serializer'
-import { GetUser, SignUp } from './user.type'
+import { GetUser, SignUp, Update } from './user.type'
 import { setCurrentUser } from 'src/middleware/setCurrentUser'
 
 @Controller()
@@ -37,6 +38,22 @@ export class UserController {
   ) {
     const id = req.currentUserId!
     const user = await this.userService.getById({ id })
+    return res.json({ user: userSerializer(user) })
+  }
+
+  @Patch(Update.endpoint)
+  @Authorized()
+  async update(
+    @Req() req: Request<{}, {}, Update.req, {}>,
+    @Res() res: Response<Update.res>,
+  ) {
+    const userId = req.currentUserId!
+    const { inputName, inputEmail } = req.body
+    const user = await this.userService.update({
+      userId,
+      inputName,
+      inputEmail,
+    })
     return res.json({ user: userSerializer(user) })
   }
 }

--- a/backend/src/module/user/user.entity.ts
+++ b/backend/src/module/user/user.entity.ts
@@ -5,6 +5,7 @@ import {
   Entity,
   OneToMany,
   PrimaryGeneratedColumn,
+  UpdateDateColumn,
 } from 'typeorm'
 
 import { Request } from '../request/request.entity'
@@ -48,7 +49,7 @@ export class User {
   })
   created_at!: Date
 
-  @CreateDateColumn({
+  @UpdateDateColumn({
     update: true,
   })
   updated_at!: Date

--- a/backend/src/module/user/user.service.ts
+++ b/backend/src/module/user/user.service.ts
@@ -1,3 +1,4 @@
+import { CustomError } from '../../error/CustomError'
 import { AppDataSource } from '../../app-data-source'
 import { hashPassword } from '../../lib/hash'
 import { validateEntity, validatePassword } from '../../utils/validate'
@@ -15,6 +16,12 @@ type GetByIdProps = {
   id: number
 }
 
+type UpdateProps = {
+  userId: number
+  inputName: string | undefined
+  inputEmail: string | undefined
+}
+
 export class UserService {
   async signUp({ name, email, password }: SignUpProps): Promise<User> {
     validatePassword(password)
@@ -30,5 +37,21 @@ export class UserService {
 
   async getById({ id }: GetByIdProps): Promise<User> {
     return await userRepository.findOneByOrFail({ id })
+  }
+
+  async update({ userId, inputName, inputEmail }: UpdateProps): Promise<User> {
+    const user = (await userRepository.findOne({
+      where: { id: userId },
+    })) as User
+    if (inputName !== undefined) {
+      user.name = inputName
+    }
+
+    if (inputEmail !== undefined) {
+      user.email = inputEmail
+    }
+
+    await validateEntity(user)
+    return await userRepository.save(user)
   }
 }

--- a/backend/src/module/user/user.service.ts
+++ b/backend/src/module/user/user.service.ts
@@ -39,10 +39,12 @@ export class UserService {
     return await userRepository.findOneByOrFail({ id })
   }
 
-  async update({ userId, inputName, inputEmail }: UpdateProps): Promise<User> {
-    const user = (await userRepository.findOne({
-      where: { id: userId },
-    })) as User
+  async updateUserParam({
+    userId,
+    inputName,
+    inputEmail,
+  }: UpdateProps): Promise<User> {
+    const user = await userRepository.findOneByOrFail({ id: userId })
     if (inputName !== undefined) {
       user.name = inputName
     }

--- a/backend/src/module/user/user.type.ts
+++ b/backend/src/module/user/user.type.ts
@@ -32,3 +32,21 @@ export namespace GetUser {
     }
   }
 }
+
+export namespace Update {
+  export const endpoint = root
+
+  export type req = {
+    inputName: string | undefined
+    inputEmail: string | undefined
+  }
+
+  export type res = {
+    user: {
+      id: number
+      name: string
+      email: string
+      icon_image_url: string | null
+    }
+  }
+}

--- a/backend/src/module/user/user.type.ts
+++ b/backend/src/module/user/user.type.ts
@@ -33,7 +33,7 @@ export namespace GetUser {
   }
 }
 
-export namespace Update {
+export namespace UpdateUserParam {
   export const endpoint = root
 
   export type req = {


### PR DESCRIPTION
## UserUpdateAPI作成
- Token情報から取得したIDのユーザーを更新し、更新後のユーザー情報を返すAPIです
- inputName,inputEmail片方だけの更新も可能
- balidateEntityも動作確認できてます
- icon_image_urlの更新は今回のAPIには含めてないです
## 気になる点
- user.serviceの44行目、userをnullはありえない前提にしている（controllerで認証をおこなっているため）