### PR TITLE
API_URLにNEXT_PUBLIC接頭辞を追加

### DIFF
--- a/frontend/src/lib/axios/index.ts
+++ b/frontend/src/lib/axios/index.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 export const apiClient = axios.create({
-  baseURL: process.env.HAKOBUN_API_URL,
+  baseURL: process.env.NEXT_PUBLIC_HAKOBUN_API_URL,
   headers: {
     'Content-Type': 'application/json',
     // Authorization: 'Bearer your_token',


### PR DESCRIPTION
クライアントコンポーネントで環境変数を読み取れるようにするため