### PR TITLE
完成：Feature/draft delete api

### DIFF
--- a/backend/src/migration/1731832921782-draftItem-cascade.ts
+++ b/backend/src/migration/1731832921782-draftItem-cascade.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DraftItemCascade1731832921782 implements MigrationInterface {
+    name = 'DraftItemCascade1731832921782'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "draft_item" DROP CONSTRAINT "FK_310e4ce048e2a4b26e65cd02d51"`);
+        await queryRunner.query(`ALTER TABLE "draft_item" ADD CONSTRAINT "FK_310e4ce048e2a4b26e65cd02d51" FOREIGN KEY ("draftRequestId") REFERENCES "draft_request"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "draft_item" DROP CONSTRAINT "FK_310e4ce048e2a4b26e65cd02d51"`);
+        await queryRunner.query(`ALTER TABLE "draft_item" ADD CONSTRAINT "FK_310e4ce048e2a4b26e65cd02d51" FOREIGN KEY ("draftRequestId") REFERENCES "draft_request"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/backend/src/module/draft_item/draft_item.entity.ts
+++ b/backend/src/module/draft_item/draft_item.entity.ts
@@ -18,6 +18,8 @@ export class DraftItem {
   @Column('int')
   price!: number
 
-  @ManyToOne(() => DraftRequest, (draft_request) => draft_request.draft_items)
+  @ManyToOne(() => DraftRequest, (draft_request) => draft_request.draft_items, {
+    onDelete: 'CASCADE',
+  })
   draft_request!: DraftRequest
 }

--- a/backend/src/module/draft_request/draft_request.controller.ts
+++ b/backend/src/module/draft_request/draft_request.controller.ts
@@ -1,10 +1,13 @@
 import 'reflect-metadata'
 import { Request, Response } from 'express'
-import { Controller, Req, Res, Post } from 'routing-controllers'
+import { Controller, Req, Res, Post, Delete } from 'routing-controllers'
 import {
   CreateByIdEndpoint,
   CreateByIdParam,
   CreateByIdRes,
+  RejectEndpoint,
+  RejectParam,
+  RejectRes,
 } from './draft_request.type'
 import { DraftRequestService } from './draft_request.service'
 import { draft_requestSerializer } from './draft_request.serializer'
@@ -26,6 +29,19 @@ export class DraftRequestController {
 
     return res.json({
       draft_request: draft_requestSerializer(draft_request),
+    })
+  }
+
+  @Delete(RejectEndpoint)
+  async reject(
+    @Req() req: Request<RejectParam, '', '', ''>,
+    @Res() res: Response<RejectRes>,
+  ) {
+    const draftRequestId = req.params.requestId
+    const rejectFlag = await this.draft_requestService.reject(draftRequestId)
+
+    return res.json({
+      success: rejectFlag,
     })
   }
 }

--- a/backend/src/module/draft_request/draft_request.controller.ts
+++ b/backend/src/module/draft_request/draft_request.controller.ts
@@ -37,11 +37,10 @@ export class DraftRequestController {
     @Req() req: Request<RejectParam, '', '', ''>,
     @Res() res: Response<RejectRes>,
   ) {
-    const draftRequestId = req.params.requestId
-    const rejectFlag = await this.draft_requestService.reject(draftRequestId)
-
     return res.json({
-      success: rejectFlag,
+      success: await this.draft_requestService.reject(
+        req.params.draftRequestId,
+      ),
     })
   }
 }

--- a/backend/src/module/draft_request/draft_request.service.ts
+++ b/backend/src/module/draft_request/draft_request.service.ts
@@ -13,13 +13,7 @@ export class DraftRequestService {
   }
 
   async reject(draftRequestId: number): Promise<boolean> {
-    const draftRequest = await draftRequestRepository.findOne({
-      where: { id: draftRequestId },
-    })
-    if (!draftRequest) {
-      return false
-    }
-    await draftRequestRepository.remove(draftRequest)
+    await draftRequestRepository.delete(draftRequestId)
     return true
   }
 }

--- a/backend/src/module/draft_request/draft_request.service.ts
+++ b/backend/src/module/draft_request/draft_request.service.ts
@@ -11,6 +11,17 @@ export class DraftRequestService {
     const draftRequest = RequestToDraftRequest(room)
     return await draftRequestRepository.save(draftRequest)
   }
+
+  async reject(draftRequestId: number): Promise<boolean> {
+    const draftRequest = await draftRequestRepository.findOne({
+      where: { id: draftRequestId },
+    })
+    if (!draftRequest) {
+      return false
+    }
+    await draftRequestRepository.remove(draftRequest)
+    return true
+  }
 }
 
 function RequestToDraftRequest(room: Room): DraftRequest {

--- a/backend/src/module/draft_request/draft_request.type.ts
+++ b/backend/src/module/draft_request/draft_request.type.ts
@@ -3,6 +3,7 @@ import { draft_requestSerializer } from './draft_request.serializer'
 const root = '/draft_requests'
 
 export const CreateByIdEndpoint = `${root}/:roomId`
+export const RejectEndpoint = `${root}/:requestId/reject`
 
 export type CreateByIdParam = {
   roomId: string
@@ -10,4 +11,12 @@ export type CreateByIdParam = {
 
 export type CreateByIdRes = {
   draft_request: ReturnType<typeof draft_requestSerializer>
+}
+
+export type RejectParam = {
+  requestId: number
+}
+
+export type RejectRes = {
+  success: boolean
 }

--- a/backend/src/module/draft_request/draft_request.type.ts
+++ b/backend/src/module/draft_request/draft_request.type.ts
@@ -3,7 +3,6 @@ import { draft_requestSerializer } from './draft_request.serializer'
 const root = '/draft_requests'
 
 export const CreateByIdEndpoint = `${root}/:roomId`
-export const RejectEndpoint = `${root}/:requestId/reject`
 
 export type CreateByIdParam = {
   roomId: string
@@ -13,8 +12,10 @@ export type CreateByIdRes = {
   draft_request: ReturnType<typeof draft_requestSerializer>
 }
 
+export const RejectEndpoint = `${root}/:draftRequestId/reject`
+
 export type RejectParam = {
-  requestId: number
+  draftRequestId: number
 }
 
 export type RejectRes = {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6cf2e917-856c-4f69-85ee-18ea90a0e88d)
deleteを行うAPIです。
渡されたdraft_requestIdを元にデータを削除します。
draftItemテーブルは```onDelete: 'CASCADE',```を有効にしたので自動で削除されます
